### PR TITLE
Strip dangling colors also

### DIFF
--- a/lib/fluent/plugin/out_color_stripper.rb
+++ b/lib/fluent/plugin/out_color_stripper.rb
@@ -39,16 +39,7 @@ module Fluent
     # Return uncolorized string
     #
     def uncolorize(string)
-      scan_for_colors(string).inject('') do |str, match|
-        str << (match[3] || match[4])
-      end
-    end
-
-    #
-    # Scan for colorized string
-    #
-    def scan_for_colors(string)
-      string.scan(/\033\[([0-9]+);([0-9]+);([0-9]+)m(.+?)\033\[0m|([^\033]+)/m)
+      string.gsub(/\033\[\d{1,2}(;\d{1,2}){0,2}[mGK]/, '')
     end
 
     def strip_field?(field)

--- a/test/test_color_stripper.rb
+++ b/test/test_color_stripper.rb
@@ -67,4 +67,23 @@ class ColorStripperOutputTest < Test::Unit::TestCase
 
     assert_match /tag.*required/, err.message
   end
+
+  def test_dangling_colors
+    d1 = create_driver %[
+      type color_stripper
+      tag  formatted
+    ]
+
+    d1.run do
+      d1.emit('decolorize' => "\033[0m")
+      d1.emit('decolorize' => "\033[0;36;1m")
+      d1.emit('decolorize' => "\033[0;36m")
+    end
+
+    assert_equal [
+      {'decolorize' => ''},
+      {'decolorize' => ''},
+      {'decolorize' => ''}
+    ], d1.records
+  end
 end


### PR DESCRIPTION
Finding exactly colorized string sometimes fails with unkind logs.

I modified the algorithm to finding all colorizing codes and remove it.
Please check the diff.

Fixes: #1 
